### PR TITLE
Fix README for Windows install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Browser-based version of
 Requires:
 
 * Python 3.9
+* Windows 10
 
 From within the `mapping-demo` project folder:
 
@@ -16,7 +17,7 @@ From within the `mapping-demo` project folder:
 
 ```
 python -m venv .venv
-.venv/Scripts/activate.bat
+.venv\Scripts\activate.bat
 ```
 
 2. Install the requirements:
@@ -28,7 +29,7 @@ pip install -r requirements.txt
 3. Start the local development server:
 
 ```
-python manage.py runserver
+python backend\manage.py runserver
 ```
 
 You can visit [localhost:8000](http://localhost:8000) to see the project


### PR DESCRIPTION
The original setup was done on a Linux machine, but development is going to be done on Windows, so we need to make sure the instructions work on Windows.